### PR TITLE
Performance improvement for 'fill' and 'refill'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "backbone.conduit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Moving data through backbone",
   "main": "dist/backbone.conduit.js",
   "keywords": [

--- a/dist/backbone.conduit.js
+++ b/dist/backbone.conduit.js
@@ -344,6 +344,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @param OriginalModel The model whose behavior to mimic
 	 */
 	function generateConduitModel(OriginalModel) {
+	    var defaults = _.result(OriginalModel.prototype, 'defaults');
+
 	    var ConduitModel = function(attributes, options) {
 	        var attrs = attributes || {};
 	        options || (options = {});
@@ -353,8 +355,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        if (options.collection) this.collection = options.collection;
 	        if (options.parse) attrs = this.parse(attrs, options) || {};
 
-	        // First significant change from Backbone.Model: only do defaults if necessary
-	        var defaults = _.result(this, 'defaults');
+	        // Significant change from Backbone.Model: only do defaults if necessary
 	        if (defaults) {
 	            attrs = _.defaults({}, attrs, _.result(this, 'defaults'));
 	        }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backbone.conduit",
   "description": "Moving data through backbone",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "scripts": {
     "test": "gulp test",
     "perf": "gulp test:performance",

--- a/src/shortCircuit.js
+++ b/src/shortCircuit.js
@@ -74,6 +74,8 @@ function quickCollectionSet(models, options) {
  * @param OriginalModel The model whose behavior to mimic
  */
 function generateConduitModel(OriginalModel) {
+    var defaults = _.result(OriginalModel.prototype, 'defaults');
+
     var ConduitModel = function(attributes, options) {
         var attrs = attributes || {};
         options || (options = {});
@@ -83,8 +85,7 @@ function generateConduitModel(OriginalModel) {
         if (options.collection) this.collection = options.collection;
         if (options.parse) attrs = this.parse(attrs, options) || {};
 
-        // First significant change from Backbone.Model: only do defaults if necessary
-        var defaults = _.result(this, 'defaults');
+        // Significant change from Backbone.Model: only do defaults if necessary
         if (defaults) {
             attrs = _.defaults({}, attrs, _.result(this, 'defaults'));
         }


### PR DESCRIPTION
Detect defaults in the Model we will be creating only once when short-circuiting a `set` call.  ~ 5% faster performance over a 5K item data set in testing.