### PR TITLE
Fire events for each projection method; fix for Issue #54

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install backbone.conduit
 var collection = new Backbone.Conduit.QuickCollection();
 
 // If you have a large amount of data injected onto the page, instead of 'reset(...)' do ...
-var aBigArray = [ ... ];
+var aBigArray = [ {}, {}, {} ]; // let's assume this was 100K objects
 collection.refill(aBigArray);
 
 // Or, if you need to get it asynchronously, instead of 'fetch()' do ...
@@ -49,18 +49,18 @@ Backbone.Conduit.enableWorker({
     paths: '/your/path/to/backbone.conduit'
 }).then(function() {
     var collection = new MyCollection();
-    collection.haul().then(function() {
-        console.log('Length: ' + collection.length); // <== "Length: 100000"
+    return collection.haul();
+}).then(function() {
+   console.log('Length: ' + collection.length); // <== "Length: 100000"
 
-    // Prepare the first 10 models for use
-    return collection.prepare({
-            indexes: { min: 0, max: 10}
-        });
-    }).then(function(models) {
-        console.log('Prepared: ' + models.length); // <== "Prepared: 10"
-        // Note the prepared models are also available via
-        // 'collection.get(...)' or 'collection.at(...)';
-    });
+   // Prepare the first 10 models for use
+   return collection.prepare({
+       indexes: { min: 0, max: 9}
+   });
+}).then(function(models) {
+  console.log('Prepared: ' + models.length); // <== "Prepared: 10"
+  // Note the prepared models are also available via
+  // 'collection.get(...)' or 'collection.at(...)';
 });
 
 ```

--- a/gulp-setup/tasks/link.js
+++ b/gulp-setup/tasks/link.js
@@ -2,11 +2,11 @@
 
 var gulp = require('gulp');
 var util = require('util');
-var child_process = require('child_process');
+var shelljs = require('shelljs');
 
 gulp.task('link', false, function () {
     var srcDir = process.env.PWD;
     var cmd = util.format('ln -s -f %s/src %s/node_modules', srcDir, srcDir);
     console.log(cmd);
-    child_process.execSync(cmd);
+    shelljs.exec(cmd);
 });

--- a/site/docs/SparseCollection/filterAsync.md
+++ b/site/docs/SparseCollection/filterAsync.md
@@ -56,3 +56,5 @@ collection.haul().then(function() {
 
 This applies a projection on the underlying data set, which can be removed by calling `resetProjection()`.  Note that
 to filter using an evaluation function, you must provide the function separately.  See [Custom Methods](customMethods.html) for details.
+
+When `SparseCollection.filterAsync()` completes, it fires the `filterAsync` event prior to resolving its Promise.

--- a/site/docs/SparseCollection/mapAsync.md
+++ b/site/docs/SparseCollection/mapAsync.md
@@ -21,9 +21,10 @@ If you would like, you can provide the mapping function directly on the `SparseC
 var MyCollection = Conduit.SparseCollection.extend({
     mapSpec: {
         method: 'translateToGerman'
-    },
+    }
+
     // ...
-};
+)};
 
 var collection = new MyCollection();
 collection.haul().then(function() {
@@ -33,4 +34,6 @@ collection.haul().then(function() {
 });
 ```
 
-This applies a projection on the underlying data set, which can be removed by calling `resetProjection()`.  
+This applies a projection on the underlying data set, which can be removed by calling `resetProjection()`.
+
+When `SparseCollection.mapAsync()` completes, it fires the `mapAsync` event prior to resolving its Promise.

--- a/site/docs/SparseCollection/sortAsync.md
+++ b/site/docs/SparseCollection/sortAsync.md
@@ -29,3 +29,5 @@ collection.sortAsync({
 This applies a Projection to your data set.  Also, note the resulting context of the sorting function will be provided 
 by the resolved `Promise`.  See the [Data Projections Section of SparseCollection Usage](usage.html#data-projections) for 
 details.
+
+When `SparseCollection.sortAsync()` completes, it fires the `sortAsync` event prior to resolving its Promise.

--- a/site/docs/SparseCollection/usage.md
+++ b/site/docs/SparseCollection/usage.md
@@ -135,7 +135,7 @@ objects that will represent the items in the collection.  Note it utilizes the c
 `userName` key from the main UI thread, shown as `this.userName` above.
 
 ## Data Projections
-Since the full copy of the data is managed on the worker thread, many/most synchronous `Backbone.Collection` method calls
+Since the full copy of the data is managed on the worker thread, most synchronous `Backbone.Collection` method calls
 on a `sparseData`-enabled collection will throw an error.  Instead, `Conduit` provides alternative, asynchronous methods
 that return promises.
 
@@ -159,6 +159,9 @@ collection.filterAsync(
     // The data is now back to its un-filtered state
 });
 ```
+
+Finally, all data projection methods emit their own events (i.e. `sortAsync`, `filterAsync`, `mapAsync`) upon completion
+to differentiate themselves from the comparable `Backbone.Collection` synchronous methods.
 
 
 ## Limitations

--- a/spec/browser/haul.browserSpec.js
+++ b/spec/browser/haul.browserSpec.js
@@ -56,8 +56,11 @@ describe('The haul module', function() {
             collection.reset();
         });
 
-        it('receives the sample data', function() {
-            expect(haulAndWait(collection)).to.eventually.have.length(3);
+        it('receives the sample data', function(done) {
+            haulAndWait(collection).then(function() {
+                expect(collection).to.have.length(3);
+                done();
+            });
         });
 
         it('contains sorted data', function(done) {

--- a/spec/browser/setup.js
+++ b/spec/browser/setup.js
@@ -5,7 +5,6 @@ var sinon = window.sinon;
 delete window.sinon;
 var chai = require('chai');
 var sinonChai = require('sinon-chai');
-var chaiAsPromised = require('chai-as-promised');
 var Backbone = require('backbone');
 var Conduit = require('src/index');
 
@@ -22,7 +21,6 @@ require('./haul.browserSpec.js');
 
 window.expect = chai.expect;
 chai.use(sinonChai);
-chai.use(chaiAsPromised);
 
 function getSampleData() {
     return[

--- a/spec/sparseData.spec.js
+++ b/spec/sparseData.spec.js
@@ -349,6 +349,17 @@ describe("The sparseData module", function() {
                 });
         });
 
+        it('fires a "sortAsync" event after sorting', function(done) {
+            var eventSpy = this.sinon.spy();
+            collection.on('sortAsync', eventSpy);
+            collection.sortAsync({
+                property: 'name'
+            }).then(function() {
+                expect(eventSpy.callCount).to.equal(1);
+                done();
+            });
+        });
+
         it('filters its data in the worker', function(done) {
             collection.filterAsync({
                 where: {
@@ -363,6 +374,20 @@ describe("The sparseData module", function() {
                 done();
             });
         });
+
+        it('fires a "filterAsync" event after filtering', function(done) {
+            var eventSpy = this.sinon.spy();
+            collection.on('filterAsync', eventSpy);
+            collection.filterAsync({
+                where: {
+                    name: 'one'
+                }
+            }).then(function() {
+                expect(eventSpy.callCount).to.equal(1);
+                done();
+            });
+        });
+
 
         it('maps its data in the worker', function(done) {
             collection.mapAsync({
@@ -385,6 +410,18 @@ describe("The sparseData module", function() {
                 done();
             });
         });
+
+        it('fires a "mapAsync" event after mapping', function(done) {
+            var eventSpy = this.sinon.spy();
+            collection.on('mapAsync', eventSpy);
+            collection.mapAsync({
+                method: 'addFirstAndSecond'
+            }).then(function() {
+                expect(eventSpy.callCount).to.equal(1);
+                done();
+            });
+        });
+
 
         it('reduces data in the worker', function(done) {
             collection.reduceAsync({

--- a/src/sparseData.js
+++ b/src/sparseData.js
@@ -354,7 +354,7 @@ function sortAsync(sortSpec) {
         // NOTE:  we could work around doing this by just re-preparing the
         // models we have locally ...
         _resetPreparedModels.call(self);
-        self.trigger('sort');
+        self.trigger('sortAsync');
         return result.context;
     });
 }
@@ -404,7 +404,7 @@ function filterAsync(filterSpec) {
     }).then(function(result) {
         self.length = result.length;
         _resetPreparedModels.call(self);
-        self.trigger('filter');
+        self.trigger('filterAsync');
 
         return result.context;
     });
@@ -446,7 +446,7 @@ function mapAsync(mapSpec) {
         args: [ mapSpec ]
     }).then(function(result) {
         _resetPreparedModels.call(self);
-        self.trigger('map');
+        self.trigger('mapAsync');
         return result.context;
     });
 }


### PR DESCRIPTION
This changes the behavior of the Projection methods in `SparseCollection` (`sortAsync()`, `filterAsync()`, and `mapAsync()`) to fire unique events upon completion.

This also includes minor cleanup:

* Remove `chai-as-promised` from the testing infrastructure
* Cleanup of READMEs
